### PR TITLE
enabled stylesheet and added credits

### DIFF
--- a/groebner-solitaire.html
+++ b/groebner-solitaire.html
@@ -5,6 +5,8 @@
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
+    <link href="../pagestyle.css" type="text/css" rel="stylesheet">
+
 </head>
 <body onload="go()">
 
@@ -23,6 +25,15 @@
     <div id="applet_container"></div>
 
     <div id="phase"></div>
+
+    <p>
+    This web app was programmed by
+    <a href="https://www.geogebra.org/u/zoltan" target="_blank">Zolt&aacute;n Kov&aacute;cs</a>,
+    based on the game described in
+    <a href="http://dx.doi.org/10.4169/math.mag.89.4.235" target="_blank">an article</a>
+    by Haley Dozier and <a href="http://www.math.usm.edu/perry/" target="_blank">John Perry</a>.
+    </p>
+
 </div>
 
 <script type="text/javascript" src="deployggb.js"></script>


### PR DESCRIPTION
There are no profound changes here, merely superficial ones. The stylesheet is expected to appear in groebner-solitaire's _parent_ directory, so it is hard-coded as `../pagestyle.css`. Unless I misremember, it is not a good idea to have the stylesheet in the same directory if you want consistency with a larger website, as I've had trouble with that in the past, even when using a symbolic link (e.g., using custom fonts: it goes looking in the wrong directory).